### PR TITLE
feat: add map view & navigation control

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,19 @@
 <script setup lang="ts">
+// This starter template is using Vue 3 <script setup> SFCs
+// Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
+import MainView from './components/MapView.vue'
+import TheNavigation from './components/TheNavigation.vue';
 </script>
 
 <template>
   <VApp>
+    <TheNavigation></TheNavigation>
+
+    <VMain>
+        <MainView 
+        class="pa-2" 
+        />
+    </VMain>
   </VApp>
 </template>
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, watchEffect, watch } from 'vue'
 import useStore from '../store';
 
 const { store } = useStore()
@@ -20,10 +20,19 @@ const fullSource = computed(() => {
   return url + '?' + params.toString()
 })
 
+const mapViewFrame = ref<HTMLIFrameElement | null>(null)
+watchEffect(() => {
+  if (mapViewFrame.value != null) {
+    store.viewPort.width = mapViewFrame.value.getBoundingClientRect().width
+    store.viewPort.height = mapViewFrame.value.getBoundingClientRect().height
+  }
+})
 </script>
 
 <template>
   <iframe
+    id="map-view"
+    ref="mapViewFrame"
     width="100%"
     height="100%"
     frameborder="0"

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import useStore from '../store';
+
+const { store } = useStore()
+
+const center = computed((): [number, number] => {
+  return store.matrix[store.currentBlock.row][store.currentBlock.col]
+})
+
+const fullSource = computed(() => {
+  let url = new URL('https://www.google.com/maps/embed/v1/view')
+
+  const params = new URLSearchParams()
+  params.append('key', import.meta.env.VITE_GMAP_API_KEY)
+  params.append('zoom', store.zoom.toString())
+  params.append('maptype', 'satellite')
+  params.append('center', `${center.value[0]}, ${center.value[1]}`)
+
+  return url + '?' + params.toString()
+})
+
+</script>
+
+<template>
+  <iframe
+    width="100%"
+    height="100%"
+    frameborder="0"
+    style="border: 0"
+    referrerpolicy="no-referrer-when-downgrade"
+    :src="fullSource"
+    allowfullscreen
+  ></iframe>
+</template>
+
+<style scoped>
+
+</style>

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -4,9 +4,6 @@ import useStore from '../store'
 
 const { store, navUp, navRight, navDown, navLeft } = useStore()
 
-const matrixRows =  computed(() => store.matrix.length);
-const matrixCols =  computed(() => store.matrix[0].length);
-
 </script>
 
 <template>
@@ -17,7 +14,7 @@ const matrixCols =  computed(() => store.matrix[0].length);
     <VCard>
       <VCardTitle>Navigation</VCardTitle>
       <VCardSubtitle>
-        {{ matrixRows }} x {{ matrixCols }}
+        {{ store.matrixRows }} x {{ store.matrixCols }}
       </VCardSubtitle>
       <VCardText>
 
@@ -43,7 +40,7 @@ const matrixCols =  computed(() => store.matrix[0].length);
             label="Row"
             type="number"
             :min="0"
-            :max="matrixRows - 1"
+            :max="store.matrixRows - 1"
           />
 
           <VTextField
@@ -51,7 +48,7 @@ const matrixCols =  computed(() => store.matrix[0].length);
             label="Col"
             type="number"
             :min="0"
-            :max="matrixCols - 1"
+            :max="store.matrixCols - 1"
           ></VTextField>
       </VCardText>
 

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -52,6 +52,17 @@ const { store, navUp, navRight, navDown, navLeft } = useStore()
           ></VTextField>
       </VCardText>
 
+      <!-- zoom control -->
+      <VCardText>
+        <VTextField
+        v-model="store.zoom"
+        label="Zoom"
+        type="number"
+        prepend-inner-icon="mdi-magnify-plus"
+        max="20"
+        ></VTextField>
+      </VCardText>
+
       <VDivider />
 
       <!-- options -->

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import useStore from '../store'
+
+const { store, navUp, navRight, navDown, navLeft } = useStore()
+
+const matrixRows =  computed(() => store.matrix.length);
+const matrixCols =  computed(() => store.matrix[0].length);
+
+</script>
+
+<template>
+  <VNavigationDrawer
+    permanent
+    width="300"
+  >
+    <VCard>
+      <VCardTitle>Navigation</VCardTitle>
+      <VCardSubtitle>
+        {{ matrixRows }} x {{ matrixCols }}
+      </VCardSubtitle>
+      <VCardText>
+
+      </VCardText>
+      <VCardText>
+        <div
+         tag="section"
+         aria-label="Navigation joystick"
+          class="joystick justify-center align-items-center mb-3"
+          >
+          <VBtn icon="mdi-arrow-up-bold" data-up @click="navUp"></VBtn>
+          <VBtn icon="mdi-arrow-left-bold" data-left @click="navLeft"></VBtn>
+          <VBtn icon="mdi-arrow-right-bold" data-right @click="navRight"></VBtn>
+          <VBtn icon="mdi-arrow-down-bold" data-down @click="navDown"></VBtn>
+        </div>        
+      </VCardText>
+      <VCardSubtitle>
+        Item
+      </VCardSubtitle>
+      <VCardText class="d-flex">
+          <VTextField 
+            v-model="store.currentBlock.row"
+            label="Row"
+            type="number"
+            :min="0"
+            :max="matrixRows - 1"
+          />
+
+          <VTextField
+            v-model="store.currentBlock.col"
+            label="Col"
+            type="number"
+            :min="0"
+            :max="matrixCols - 1"
+          ></VTextField>
+      </VCardText>
+
+      <VDivider />
+
+      <!-- options -->
+      <VCardTitle>Options</VCardTitle>
+      <VCardSubtitle>Start point</VCardSubtitle>
+      <VCardText>        
+          <VTextField
+          v-model="store.startPoint[0]"
+          label="Lat"
+        ></VTextField>
+        <VTextField
+          v-model="store.startPoint[1]"
+          label="Lng"
+        ></VTextField>
+      </VCardText>
+
+      <VCardSubtitle>End point</VCardSubtitle>
+        <VCardText>
+          <VTextField
+          v-model="store.endPoint[0]"
+          label="Lat"
+        ></VTextField>
+        <VTextField
+          v-model="store.endPoint[1]"
+          label="Lng"
+        ></VTextField>
+        </VCardText>
+    </VCard>
+  </VNavigationDrawer>
+</template>
+
+<style scoped>
+  .joystick {
+    display: grid;
+    grid-template-areas: ". up ."
+    "left . right"
+    ". down ."
+    ;
+
+    /* place-items: center; */
+  }
+
+  .joystick button[data-up] {
+    grid-area: up
+  }
+
+  .joystick button[data-left] {
+    grid-area: left
+  }
+
+  .joystick button[data-right] {
+    grid-area: right
+  }
+
+  .joystick button[data-down] {
+    grid-area: down
+  }
+</style>

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,85 @@
+import { reactive, computed } from 'vue'
+
+type CoordinatePair = [number, number]
+
+const ROW_LENGTH = 0.0025;
+const COL_LENGTH = 0.0025;
+
+const store = reactive({
+  currentBlock: {row: 0, col: 0},
+  zoom: 18,
+
+  startPoint: [32.32715235751756, 15.08581394993159],
+  endPoint: [32.193612259300686, 15.138809048123479],
+
+  matrix: computed((): CoordinatePair[][] =>  {
+    const result: CoordinatePair[][] = []
+
+    let currentRow = store.startPoint[0]
+    while (currentRow > store.endPoint[0]) {
+      
+      const matrixRow: CoordinatePair[] = []
+
+      currentRow -= ROW_LENGTH
+      let currentCol = store.startPoint[1]
+
+      while (currentCol < store.endPoint[1]) {
+        currentCol += COL_LENGTH
+        matrixRow.push([currentRow, currentCol])
+      }
+
+      result.push(matrixRow)
+    }
+
+    // const rows = Math.round((store.startPoint[0] - store.endPoint[0]) / 10)
+
+    return result
+  }),
+
+  
+})
+
+function updateCurrentBlock (row: number, col: number): void {
+  if (row < 0) {
+    row = 0
+  } else if (row > store.matrix.length) {
+    row = store.matrix.length
+  }
+
+  if (col < 0) {
+    col = 0
+  } else if (col > store.matrix[0].length) {
+    col = store.matrix[0].length
+  }
+
+  store.currentBlock = {row, col}
+}
+
+function navUp() {
+  updateCurrentBlock(store.currentBlock.row - 1, store.currentBlock.col)
+}
+
+
+function navRight () {
+  updateCurrentBlock(store.currentBlock.row, store.currentBlock.col +1)
+}
+
+function navDown () {
+  updateCurrentBlock(store.currentBlock.row + 1, store.currentBlock.col)
+}
+
+function navLeft () {
+  updateCurrentBlock(store.currentBlock.row, store.currentBlock.col -1)
+}
+
+export default function useStore () {
+
+  return {
+    store,
+
+    navUp,
+    navRight,
+    navDown,
+    navLeft
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,29 +2,43 @@ import { reactive, computed } from 'vue'
 
 type CoordinatePair = [number, number]
 
-const ROW_LENGTH = 0.0025;
-const COL_LENGTH = 0.0025;
+
+// stupidly measured but effective numbers ^_^
+// each pixel sums up to 0.000002538 coordinate unit at zoom level 18
+//
+// TODO: make this ratio dynamic and take into account zoom levels other than 18
+const mapToPixelRatio = 0.000002538
 
 const store = reactive({
-  currentBlock: {row: 0, col: 0},
   zoom: 18,
 
-  startPoint: [32.32715235751756, 15.08581394993159],
-  endPoint: [32.193612259300686, 15.138809048123479],
+  viewPort: {
+    width: 100,
+    height: 100,
+  },
+
+  blockWidth: computed((): number => store.viewPort.width * mapToPixelRatio),
+  blockHeight: computed((): number => store.viewPort.height * mapToPixelRatio),
+
+  currentBlock: {row: 0, col: 0},
+
+  startPoint: ['32.32715235751756', '15.08581394993159'],
+  endPoint: ['32.193612259300686', '15.138809048123479'],
 
   matrix: computed((): CoordinatePair[][] =>  {
-    const result: CoordinatePair[][] = []
+    const parsedStartPoint = store.startPoint.map(parseFloat)
+    const parsedEndPoint = store.endPoint.map(parseFloat)
 
-    let currentRow = store.startPoint[0]
-    while (currentRow > store.endPoint[0]) {
-      
+    const result: CoordinatePair[][] = []
+    
+    let currentRow =  parsedStartPoint[0]
+    while (currentRow > parsedEndPoint[0]) {
       const matrixRow: CoordinatePair[] = []
 
-      currentRow -= ROW_LENGTH
-      let currentCol = store.startPoint[1]
-
-      while (currentCol < store.endPoint[1]) {
-        currentCol += COL_LENGTH
+      currentRow -= store.blockWidth
+      let currentCol = parsedStartPoint[1]
+      while (currentCol < parsedEndPoint[1]) {
+        currentCol += store.blockHeight
         matrixRow.push([currentRow, currentCol])
       }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,7 +36,10 @@ const store = reactive({
     return result
   }),
 
-  
+
+  matrixRows:  computed((): number => store.matrix.length),
+
+  matrixCols:  computed((): number => store.matrix[0].length),
 })
 
 function updateCurrentBlock (row: number, col: number): void {
@@ -61,7 +64,14 @@ function navUp() {
 
 
 function navRight () {
-  updateCurrentBlock(store.currentBlock.row, store.currentBlock.col +1)
+  let newCol = store.currentBlock.col +1
+  let newRow = store.currentBlock.row
+  if (store.currentBlock.col === store.matrixCols - 1) {
+    newCol = 0
+    newRow++
+  }
+
+  updateCurrentBlock(newRow, newCol)
 }
 
 function navDown () {
@@ -69,7 +79,14 @@ function navDown () {
 }
 
 function navLeft () {
-  updateCurrentBlock(store.currentBlock.row, store.currentBlock.col -1)
+  let newCol = store.currentBlock.col - 1
+  let newRow = store.currentBlock.row
+  if (store.currentBlock.col === 0) {
+    newCol = store.matrixCols - 1
+    newRow--
+  }
+  
+  updateCurrentBlock(newRow, newCol)
 }
 
 export default function useStore () {


### PR DESCRIPTION
This PR adds the map viewport and navigation control to form the basic skeleton of the app. The idea basically is to split a rectangular area (specified by the user) into a matrix of blocks. The blocks' matrix is navigatable and reflects the changes on the map.

**List of the main features included**

- Navigation "joystick" & zoom control
- Fields to allow the user to specify the area to locate spots in

![image](https://user-images.githubusercontent.com/22858957/193473851-403aef74-b308-4cc6-9f1f-05fed0946219.png)
