### PR TITLE
feat (mission): add mult-mission support to the app

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@
 // Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
 import MainView from './components/MapView.vue'
 import TheNavigation from './components/TheNavigation.vue';
+import MissionDialog from './components/MissionDialog.vue'
 </script>
 
 <template>
@@ -13,6 +14,8 @@ import TheNavigation from './components/TheNavigation.vue';
         <MainView 
         class="pa-2" 
         />
+
+        <MissionDialog />
     </VMain>
   </VApp>
 </template>

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { ref, computed, watchEffect, watch } from 'vue'
+import { toRef, computed } from 'vue'
 import useStore from '../store';
+import useNavigation from '../navigation';
 
 const { store } = useStore()
-
-const center = computed(() => store.currentBlock.coordinates)
+const { currentBlock } = useNavigation()
+const center = computed(() => currentBlock.value?.coordinates ?? [0, 0])
 
 const fullSource = computed(() => {
   let url = new URL('https://www.google.com/maps/embed/v1/view')
@@ -18,27 +19,40 @@ const fullSource = computed(() => {
   return url + '?' + params.toString()
 })
 
-const mapViewFrame = ref<HTMLIFrameElement | null>(null)
-watchEffect(() => {
-  if (mapViewFrame.value != null) {
-    store.viewPort.width = mapViewFrame.value.getBoundingClientRect().width
-    store.viewPort.height = mapViewFrame.value.getBoundingClientRect().height
-  }
-})
+const mapViewFrame = toRef(store, 'mapViewFrame')
 </script>
 
 <template>
-  <iframe
-    id="map-view"
+  <div
     ref="mapViewFrame"
-    width="100%"
-    height="100%"
-    frameborder="0"
-    style="border: 0"
-    referrerpolicy="no-referrer-when-downgrade"
-    :src="fullSource"
-    allowfullscreen
-  ></iframe>
+    style="height: 100%; width: 100%"
+  >
+    <iframe
+      v-if="currentBlock != null"
+      id="map-view"
+      ref="mapViewFrame"
+      width="100%"
+      height="100%"
+      frameborder="0"
+      style="border: 0"
+      referrerpolicy="no-referrer-when-downgrade"
+      :src="fullSource"
+      allowfullscreen
+    ></iframe>
+    <VCard 
+      v-else
+      class="d-flex flex-column justify-center text-center"
+      width="100%"
+      height="100%"
+    >
+      <VCardTitle>
+        No data to display.
+      </VCardTitle>
+      <VCardSubtitle>
+        Please load a mission or start a new mission.
+      </VCardSubtitle>
+    </VCard>
+  </div>  
 </template>
 
 <style scoped>

--- a/src/components/MissionDialog.vue
+++ b/src/components/MissionDialog.vue
@@ -1,0 +1,135 @@
+<!-- 
+  A dialog to create/edit mission data
+ -->
+<script setup lang="ts">
+import { toRef, watch, watchEffect } from 'vue';
+import type { WatchStopHandle } from 'vue';
+import useStore from '../store'
+import useMission from '../mission'
+
+const  { store } = useStore()
+const { missionStore, saveMission, updateMissionsList, generateBlocksMatrix } = useMission()
+
+const dialog = toRef(missionStore, 'dialog')
+
+/*
+ * 
+ */
+let areaWatchHandle: WatchStopHandle | null = null
+watch(() => dialog.value.visible, (newVal) => {
+  if (newVal) {
+    dialog.value.regenerateMatrix = false
+
+    areaWatchHandle = watch([
+      () => dialog.value.mission.startPoint,
+      () => dialog.value.mission.endPoint
+    ], () => {
+      dialog.value.regenerateMatrix = true
+    },  { deep: true } )
+
+  } else {
+    if (areaWatchHandle != null) {
+      areaWatchHandle()
+    }
+  }
+},)
+
+function onSave (): void {
+  if (dialog.value.regenerateMatrix || dialog.value.newMission) {
+
+    const viewportBounding = store.mapViewFrame!.getBoundingClientRect()
+
+    dialog.value.mission.matrix = generateBlocksMatrix({
+        startPoint: dialog.value.mission.startPoint,
+        endPoint: dialog.value.mission.endPoint,
+      },
+      {
+        width: viewportBounding.width,
+        height: viewportBounding.height
+      }
+    ) 
+  }
+  
+  saveMission(dialog.value.mission)
+  dialog.value.visible = false
+
+  if (dialog.value.newMission) {
+    dialog.value.newMission = false
+    updateMissionsList()
+  }
+}
+
+function onCancel (): void {
+  dialog.value.visible = false
+}
+</script>
+
+<template>
+<VDialog
+  v-model="dialog.visible"
+>
+  <VCard>
+    <VCardTitle>Mission</VCardTitle>
+    
+    <VCardText>
+      <VTextField
+        v-model="dialog.mission.title"
+        label="Title"
+      />
+    </VCardText>
+
+    <VCardSubtitle>Start point</VCardSubtitle>
+    <VCardText>
+      <VRow>        
+        <VTextField
+          v-model="dialog.mission.startPoint[0]"
+          label="Latitude"
+          class="v-col v-col-lg-6"
+        />
+        <VTextField
+          v-model="dialog.mission.startPoint[1]"
+          label="Longitude"
+          class="v-col v-col-lg-6"
+        />
+      </VRow>
+    </VCardText>
+
+    <VCardSubtitle>End point</VCardSubtitle>
+    <VCardText>
+      <VRow>
+        <VTextField
+          v-model="dialog.mission.endPoint[0]"
+          label="Latitude"
+          class="v-col v-col-lg-6"
+
+        />
+        <VTextField
+          v-model="dialog.mission.endPoint[1]"
+          label="Longitude"
+          class="v-col v-col-lg-6"
+        />
+      </VRow>
+
+      <VAlert 
+        v-show="!dialog.newMission && dialog.regenerateMatrix"
+        type="warning"
+        title="Possible loss of blocks data"
+      >
+        The area details of the mission has been updated (start point/end point). Saving the changes will cause all of the mission data to be overwritten
+      </VAlert>
+    </VCardText>
+
+    <VCardActions>
+      <VSpacer />
+      <VBtn
+        @click="onCancel"
+      >Cancel</VBtn>
+      <VBtn 
+        color="primary"
+        variant="flat" 
+        @click="onSave"
+      >Save</VBtn>
+    </VCardActions>
+  </VCard>
+</VDialog>
+</template>

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { toRef, onMounted } from 'vue'
 import useStore from '../store'
+import useMission from '../mission'
+import useNavigation from '../navigation'
 
-const { store, navUp, navRight, navDown, navLeft } = useStore()
+const { store } = useStore()
+
 
 const highlightOptions = [
 {
@@ -19,6 +22,24 @@ const highlightOptions = [
   },
 ]
 
+/*
+ * Mission
+ */
+const { 
+  missionStore, 
+  updateMissionsList,
+  showNewDialog: showNewMissionDialog
+ } = useMission()
+
+updateMissionsList()
+
+const { 
+  currentBlockIndex,
+  currentBlock,
+  matrixCols,
+  matrixRows,
+  navUp, navRight, navDown, navLeft } = useNavigation()
+
 </script>
 
 <template>
@@ -26,92 +47,90 @@ const highlightOptions = [
     permanent
     width="300"
   >
-    <VCard>
+    <VCard v-if="currentBlock != null">
       <VCardTitle>Navigation</VCardTitle>
-      <VCardSubtitle>
-        {{ store.matrixRows }} x {{ store.matrixCols }}
-      </VCardSubtitle>
+        <VCardSubtitle>
+          {{ matrixRows }} x {{ matrixCols }}
+        </VCardSubtitle>
 
-      <VCardText>
-        <!-- zoom control -->
-        <VTextField
-          v-model="store.zoom"
-          label="Zoom"
-          type="number"
-          prepend-inner-icon="mdi-magnify-plus"
-          max="20"
-        />
-
-        <div
-         tag="section"
-         aria-label="Navigation joystick"
-          class="joystick justify-center align-items-center mb-3"
-          >
-          <VBtn icon="mdi-arrow-up-bold" data-up @click="navUp"></VBtn>
-          <VBtn icon="mdi-arrow-left-bold" data-left @click="navLeft"></VBtn>
-          <VBtn icon="mdi-arrow-right-bold" data-right @click="navRight"></VBtn>
-          <VBtn icon="mdi-arrow-down-bold" data-down @click="navDown"></VBtn>
-        </div>        
-      </VCardText>
-      <VCardSubtitle>
-        Block index
-      </VCardSubtitle>
-      <VCardText class="d-flex">
-          <VTextField 
-            v-model="store.currentBlockIndex.row"
-            label="Row"
+        <VCardText>
+          <!-- zoom control -->
+          <VTextField
+            v-model="store.zoom"
+            label="Zoom"
             type="number"
-            :min="0"
-            :max="store.matrixRows - 1"
+            prepend-inner-icon="mdi-magnify-plus"
+            max="20"
           />
 
-          <VTextField
-            v-model="store.currentBlockIndex.col"
-            label="Col"
-            type="number"
-            :min="0"
-            :max="store.matrixCols - 1"
-          ></VTextField>
-      </VCardText>
-      <VCardSubtitle>
-        Block details
-      </VCardSubtitle>
-      <VCardText>
-        <VTable>
-          <tbody>
-            <tr>
-              <th>Latitude</th>
-              <td>{{ store.currentBlock.coordinates[0]}}</td>
-            </tr>
-            <tr>
-              <th>Longitude</th>
-              <td> {{ store.currentBlock.coordinates[1] }}</td>
-            </tr>
-          </tbody>
-        </VTable>
-        
-      </VCardText>
+          <div
+          tag="section"
+          aria-label="Navigation joystick"
+            class="joystick justify-center align-items-center mb-3"
+            >
+            <VBtn icon="mdi-arrow-up-bold" data-up @click="navUp"></VBtn>
+            <VBtn icon="mdi-arrow-left-bold" data-left @click="navLeft"></VBtn>
+            <VBtn icon="mdi-arrow-right-bold" data-right @click="navRight"></VBtn>
+            <VBtn icon="mdi-arrow-down-bold" data-down @click="navDown"></VBtn>
+          </div>
+        </VCardText>
+        <VCardSubtitle>
+          Block index
+        </VCardSubtitle>
+        <VCardText class="d-flex">
+            <VTextField
+              v-model="currentBlockIndex.row"
+              label="Row"
+              type="number"
+              :min="0"
+              :max="matrixRows - 1"
+            />
 
-      <VCardText>
-        <!-- highlight control -->
-        <VSelect
-          v-model="store.currentBlock.highlight"
-          :items="highlightOptions"
-          item-value="value"
-          item-title="text"
-          label="Highlight"
-          hint="Choose how to categorize this block"
-        />
+            <VTextField
+              v-model="currentBlockIndex.col"
+              label="Col"
+              type="number"
+              :min="0"
+              :max="matrixCols - 1"
+            ></VTextField>
+        </VCardText>
+        <VCardSubtitle>
+          Block details
+        </VCardSubtitle>
+        <VCardText>
+          <VTable>
+            <tbody>
+              <tr>
+                <th>Latitude</th>
+                <td>{{ currentBlock.coordinates[0]}}</td>
+              </tr>
+              <tr>
+                <th>Longitude</th>
+                <td> {{ currentBlock.coordinates[1] }}</td>
+              </tr>
+            </tbody>
+          </VTable>
+        </VCardText>
 
-        <VTextarea 
-          v-model="store.currentBlock.note"
-          label="Block notes"
-          rows="2"
-          auto-grow
-        />
-      </VCardText>
+        <VCardText>
+          <!-- highlight control -->
+          <VSelect
+            v-model="currentBlock.highlight"
+            :items="highlightOptions"
+            item-value="value"
+            item-title="text"
+            label="Highlight"
+            hint="Choose how to categorize this block"
+          />
 
-      <VDivider />
+          <VTextarea 
+            v-model="currentBlock.note"
+            label="Block notes"
+            rows="2"
+            auto-grow
+          />
+        </VCardText>
+    </VCard>
 
     <!-- mission -->
     <VCard>

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -113,31 +113,26 @@ const highlightOptions = [
 
       <VDivider />
 
-      <!-- options -->
-      <VCardTitle>Options</VCardTitle>
-      <VCardSubtitle>Start point</VCardSubtitle>
-      <VCardText>        
-          <VTextField
-          v-model="store.startPoint[0]"
-          label="Lat"
-        ></VTextField>
-        <VTextField
-          v-model="store.startPoint[1]"
-          label="Lng"
-        ></VTextField>
-      </VCardText>
+    <!-- mission -->
+    <VCard>
+      <VCardTitle>Mission</VCardTitle>
 
-      <VCardSubtitle>End point</VCardSubtitle>
-        <VCardText>
-          <VTextField
-          v-model="store.endPoint[0]"
-          label="Lat"
-        ></VTextField>
-        <VTextField
-          v-model="store.endPoint[1]"
-          label="Lng"
-        ></VTextField>
-        </VCardText>
+      <VCardText>
+        <VSelect 
+          v-model="missionStore.missionKey"
+          :items="missionStore.missions"
+          item-value="id"
+          item-title="title"
+        />
+      </VCardText>
+      <VCardActions>
+        <VBtn
+          block
+          @click="showNewMissionDialog"
+        >
+          New mission
+        </VBtn>
+      </VCardActions>
     </VCard>
   </VNavigationDrawer>
 </template>

--- a/src/mission.ts
+++ b/src/mission.ts
@@ -123,3 +123,13 @@ export default function useMission () {
     updateMissionsList,
   }
 }
+
+/*
+ * a prototype, simple periodic auto save
+ */
+setInterval(() => {
+  if (missionStore.internalMissionKey) {
+    saveMission(missionStore.mission)
+    // console.info('[MissionState]: automatically stored changes (or no changes).')
+  }
+}, 15 * 1000)

--- a/src/mission.ts
+++ b/src/mission.ts
@@ -1,0 +1,125 @@
+import { reactive, unref, computed } from 'vue'
+import type { LocatorBlock, LocatorMission  } from './types'
+
+// stupidly measured but effective numbers ^_^
+// each pixel sums up to 0.000002538 coordinate unit at zoom level 19
+//
+// TODO: make this ratio dynamic and take into account zoom levels other than 19
+const mapToPixelRatio = 0.000002538
+
+function genEmptyMission (): LocatorMission {
+  return {
+    title: `New mission ${Date.now()}`,
+    matrix: [],
+    startPoint: ['32.32715235751756', '15.08581394993159'],
+    endPoint: ['32.193612259300686', '15.138809048123479'],
+  
+    currentBlockIndex: {row: 0, col:  0},
+  }
+}
+
+const missionStore = reactive({
+  missions: [] as Array<{ id: string, title: string }>,
+
+  internalMissionKey: '',
+  missionKey: computed({
+    set(newKey: string) {
+      if (missionStore.internalMissionKey) {
+        saveMission(missionStore.mission)
+      }
+
+      missionStore.internalMissionKey = newKey
+      loadMission(newKey)
+    },
+    get (): string {
+      return missionStore.internalMissionKey
+    }
+  }),
+
+  mission: genEmptyMission() as LocatorMission,
+
+  dialog: {
+    visible: false,
+    regenerateMatrix: false,
+    newMission: false,
+    mission: genEmptyMission() as LocatorMission,
+  }
+})
+
+/*
+ * Missions' list
+ */
+function updateMissionsList () {
+  const data = 
+    Object.keys(localStorage).filter((itemKey) => itemKey.startsWith('$mission-')).map((item) => {
+      return { id: item, title: item.substring(9) }
+    })
+
+  missionStore.missions = data
+}
+
+/* 
+ * blocks' matrix
+ */
+function generateBlocksMatrix (
+  area: Pick<LocatorMission, 'startPoint' | 'endPoint'>,
+  viewportSize: {width: number, height: number}
+   ): LocatorBlock[][] {
+  const parsedStartPoint = area.startPoint.map(parseFloat)
+  const parsedEndPoint = area.endPoint.map(parseFloat)
+
+  const blockWidth = viewportSize.width * mapToPixelRatio
+  const blockHeight = viewportSize.height * mapToPixelRatio
+
+  const matrix: LocatorBlock[][] = []
+  
+  let currentRow =  parsedStartPoint[0]
+  while (currentRow > parsedEndPoint[0]) {
+    const blocksRow: LocatorBlock[] = []
+
+    currentRow -= blockWidth
+    let currentCol = parsedStartPoint[1]
+    while (currentCol < parsedEndPoint[1]) {
+      currentCol += blockHeight
+      blocksRow.push({
+        coordinates: [currentRow, currentCol],
+        visited: false,
+        highlight: 'NONE',
+        note: '',
+      })
+    }
+
+    matrix.push(blocksRow)
+  }
+
+  return matrix
+}
+
+function loadMission (missionKey: string): void {
+  missionStore.mission = JSON.parse(localStorage.getItem(missionKey)!)
+}
+
+function saveMission (mission: LocatorMission): void {
+  localStorage.setItem(`$mission-${mission.title}`, JSON.stringify(unref(mission)))
+}
+
+function showNewDialog () {
+  missionStore.dialog.mission = genEmptyMission()
+  missionStore.dialog.newMission = true
+  missionStore.dialog.regenerateMatrix = true
+  missionStore.dialog.visible = true
+}
+
+export default function useMission () {
+  return {
+    missionStore,
+
+    generateBlocksMatrix,
+
+    showNewDialog,
+
+    saveMission,
+
+    updateMissionsList,
+  }
+}

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,0 +1,89 @@
+import { reactive, computed, toRef, watch, toRefs } from 'vue'
+import useMission from './mission';
+import type { LocatorBlock } from "./types";
+
+const { missionStore } = useMission()
+const mission = toRef(missionStore, 'mission')
+
+const navUtils = reactive({
+  currentBlockIndex: computed(() => mission.value.currentBlockIndex),
+  currentBlock: computed((): LocatorBlock | null => {
+    if (mission.value == null) { return null}
+
+    const rowIndex = mission.value?.currentBlockIndex?.row
+    if (rowIndex == null) { return null }
+
+    const blocksRow = mission.value?.matrix[rowIndex]
+    return blocksRow != null ? blocksRow[mission.value?.currentBlockIndex?.col] : null
+  }),
+
+  matrixRows:  computed((): number => mission.value?.matrix?.length ?? 0),
+  matrixCols:  computed((): number => mission.value?.matrix[0]?.length ?? 0),
+})
+
+/* 
+*  navigation (current block updates)
+*/
+watch(() => mission.value.currentBlockIndex, () => {
+  if (navUtils.currentBlock != null && !navUtils.currentBlock?.visited) {
+    navUtils.currentBlock.visited = true
+  }
+})
+
+function updateCurrentBlock (row: number, col: number): void {
+  if (row < 0) {
+    row = 0
+  } else if (row > mission.value.matrix.length) {
+    row = mission.value.matrix.length
+  }
+
+  if (col < 0) {
+    col = 0
+  } else if (col > mission.value.matrix[0].length) {
+    col = mission.value.matrix[0].length
+  }
+
+  mission.value.currentBlockIndex = {row, col}
+}
+
+function navUp() {
+  updateCurrentBlock(mission.value.currentBlockIndex.row - 1, mission.value.currentBlockIndex.col)
+}
+
+function navRight () {
+  let newCol = mission.value.currentBlockIndex.col +1
+  let newRow = mission.value.currentBlockIndex.row
+  if (mission.value.currentBlockIndex.col === navUtils.matrixCols - 1) {
+    newCol = 0
+    newRow++
+  }
+
+  updateCurrentBlock(newRow, newCol)
+}
+
+function navDown () {
+  updateCurrentBlock(mission.value.currentBlockIndex.row + 1, mission.value.currentBlockIndex.col)
+}
+
+function navLeft () {
+  let newCol = mission.value.currentBlockIndex.col - 1
+  let newRow = mission.value.currentBlockIndex.row
+  if (mission.value.currentBlockIndex.col === 0) {
+    newCol = navUtils.matrixCols - 1
+    newRow--
+  }
+  
+  updateCurrentBlock(newRow, newCol)
+}
+
+export default function useNavigation() {
+  return {
+    ...toRefs(navUtils),
+
+    navUp,
+    navRight,
+    navDown,
+    navLeft,
+}
+}
+

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,127 +1,13 @@
-import { reactive, computed, watch } from 'vue'
-
-import type { CoordinatesPair, LocatorBlock } from './types'
-
-// stupidly measured but effective numbers ^_^
-// each pixel sums up to 0.000002538 coordinate unit at zoom level 19
-//
-// TODO: make this ratio dynamic and take into account zoom levels other than 19
-const mapToPixelRatio = 0.000002538
+import { reactive } from 'vue'
 
 const store = reactive({
   zoom: 19,
 
-  viewPort: {
-    width: 100,
-    height: 100,
-  },
-
-  blockWidth: computed((): number => store.viewPort.width * mapToPixelRatio),
-  blockHeight: computed((): number => store.viewPort.height * mapToPixelRatio),
-
-  currentBlockIndex: {row: 0, col: 0},
-  currentBlock: computed((): LocatorBlock => {
-    return store.matrix[store.currentBlockIndex.row][store.currentBlockIndex.col]
-  }),
-
-  startPoint: ['32.32715235751756', '15.08581394993159'],
-  endPoint: ['32.193612259300686', '15.138809048123479'],
-
-  matrix: computed((): LocatorBlock[][] =>  {
-    const parsedStartPoint = store.startPoint.map(parseFloat)
-    const parsedEndPoint = store.endPoint.map(parseFloat)
-
-    const result: LocatorBlock[][] = []
-    
-    let currentRow =  parsedStartPoint[0]
-    while (currentRow > parsedEndPoint[0]) {
-      const blocksRow: LocatorBlock[] = []
-
-      currentRow -= store.blockWidth
-      let currentCol = parsedStartPoint[1]
-      while (currentCol < parsedEndPoint[1]) {
-        currentCol += store.blockHeight
-        blocksRow.push({
-          coordinates: [currentRow, currentCol],
-          visited: false,
-          highlight: 'NONE',
-          note: '',
-        })
-      }
-
-      result.push(blocksRow)
-    }
-    return result
-  }),
-
-  matrixRows:  computed((): number => store.matrix.length),
-
-  matrixCols:  computed((): number => store.matrix[0].length),
+  mapViewFrame: null as HTMLDivElement | null,  
 })
-
-watch(() => store.currentBlockIndex, () => {
-  if (!store.currentBlock?.visited) {
-    store.currentBlock.visited = true
-  }
-})
-
-function updateCurrentBlock (row: number, col: number): void {
-  if (row < 0) {
-    row = 0
-  } else if (row > store.matrix.length) {
-    row = store.matrix.length
-  }
-
-  if (col < 0) {
-    col = 0
-  } else if (col > store.matrix[0].length) {
-    col = store.matrix[0].length
-  }
-
-  store.currentBlockIndex = {row, col}
-}
-
-function navUp() {
-  updateCurrentBlock(store.currentBlockIndex.row - 1, store.currentBlockIndex.col)
-}
-
-
-function navRight () {
-  let newCol = store.currentBlockIndex.col +1
-  let newRow = store.currentBlockIndex.row
-  if (store.currentBlockIndex.col === store.matrixCols - 1) {
-    newCol = 0
-    newRow++
-  }
-
-  updateCurrentBlock(newRow, newCol)
-}
-
-function navDown () {
-  updateCurrentBlock(store.currentBlockIndex.row + 1, store.currentBlockIndex.col)
-}
-
-function navLeft () {
-  let newCol = store.currentBlockIndex.col - 1
-  let newRow = store.currentBlockIndex.row
-  if (store.currentBlockIndex.col === 0) {
-    newCol = store.matrixCols - 1
-    newRow--
-  }
-  
-  updateCurrentBlock(newRow, newCol)
-}
 
 export default function useStore () {
-
   return {
     store,
-
-    navUp,
-    navRight,
-    navDown,
-    navLeft,
-
-    updateCurrentBlock,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,3 +9,16 @@ export interface LocatorBlock {
 
   note: string
 }
+
+export interface LocatorMission {
+  title: string
+
+  startPoint: [string, string]
+  endPoint: [string, string]
+
+  matrix: LocatorBlock[][]
+  currentBlockIndex: {
+    row: number 
+    col: number
+  }
+}


### PR DESCRIPTION
The PR is intended to expand the UX of the app to another level by allowing users to keep permanently their data stored in the browser's `localStorage`. Furthermore allowing multiple "missions" to be stored and the user should be able to switch between them flawlessly. 

### The required stages of this PR

- [x] add the required state management (new model)
- [x]  update the navigation state of the app so it relies on the current mission state (and not on the previous global one).
- [x] add a new interface (dialog) to support creating/editing missions
- [x] automatically save changes permanently to the local storage upon user changes (a timer should do for now)
